### PR TITLE
fix typo in featured data

### DIFF
--- a/data/featured.json
+++ b/data/featured.json
@@ -36,7 +36,7 @@
 				"logo": "img/adobe_research.png",
 				"textHeader": [
 					"<h3>Adobe Research</h3>",
-					"<p class='details'>Open-source published code form cutting-edge research at Adobe.<br/>",
+					"<p class='details'>Open-source published code from cutting-edge research at Adobe.<br/>",
 					"<a href='http://www.adobe.com/open-source.html' target='_blank'>Learn more...</a>"
 				]
 			},


### PR DESCRIPTION
I think this was supposed to be 'from cutting-edge...', right?
