### PR TITLE
Fixed assets not loading over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@ Okay, now let's take a look on how this website is codded!
     <meta name="viewport" content="width=device-width">
     <title>Adobe Open Source | Advancing technology through open initiatives</title>
     <link href="stylesheets/app.css" rel="stylesheet">
-    <link href="http://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
-    <link href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" rel="stylesheet">
+    <link href="//fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+    <link href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" rel="stylesheet">
 </head>
 
 <body class="ng-cloak" ng-controller="GitHubCtrl">
@@ -330,9 +330,9 @@ Okay, now let's take a look on how this website is codded!
         <script src="js/vendor/custom.modernizr.js"></script>
         <script src="//use.typekit.net/gad4asz.js"></script>
         <script>try{Typekit.load();}catch(e){}</script>
-        <script src="http://code.jquery.com/jquery-1.9.1.js"></script>
-        <script src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
-        <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.12/angular.min.js"></script>
+        <script src="//code.jquery.com/jquery-1.9.1.js"></script>
+        <script src="//code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.12/angular.min.js"></script>
         <script src="js/vendor/angular-resource.js"></script>
         <script src="js/foundation/foundation.js"></script>
         <script src="js/foundation/foundation.forms.js"></script>

--- a/offline.html
+++ b/offline.html
@@ -10,7 +10,7 @@
 
   
   <link rel="stylesheet" href="stylesheets/app.css">
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
 
 </head>
 <body ng-controller="OfflineCtrl">


### PR DESCRIPTION
At the moment, https://adobe.github.com doesn't load properly because insecure content is blocked on secure pages. This poses a problem for users who prefer https. This pull request decouples the asset URLs from the http(s) protocol using [protocol-relative URLs](http://www.paulirish.com/2010/the-protocol-relative-url/).
