### PR TITLE
schema Image link corrected in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All this seems interesting to you? You want to contribute to the web with Adobe?
 
 Hummm... you want to learn more about how all this is structured? A good sketch is better than a long speech, so here is a little schema:
 
-<p align="center"> <img src="https://raw2.github.com/adobe/adobe.github.com/master/img/schema_adobe_open_source.png"  alt="Adobe Open Source schema" /></p>
+<p align="center"> <img src="https://raw.github.com/adobe/adobe.github.com/master/img/schema_adobe_open_source.png"  alt="Adobe Open Source schema" /></p>
 
 The information is pulled directly from the [Github API](http://developer.github.com/v3/) and aggregated by a [NodeJS](http://nodejs.org) server (its code source is available [in this repository](https://github.com/kimchouard/server.adobe.github.com)). It is available through an simple REST API, thanks to [restify](http://mcavage.me/node-restify/).
 


### PR DESCRIPTION
Fixed Schema image link in Architecture section.
## Earlier -

![schema_old](https://cloud.githubusercontent.com/assets/4817493/5196994/403e6c9e-7561-11e4-8097-990627952cbe.png)
## Modified -

![schema_new](https://cloud.githubusercontent.com/assets/4817493/5197002/507472ca-7561-11e4-90ca-787af88662f1.png)
