### PR TITLE
Changed request to server-adobe-github.herokuapp.com to a relative protocol

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -15,7 +15,7 @@ var app = angular.module("AdobeOpenSource", ["ngResource"]);
 
 //Get Adobe Github repos & orgs
 app.factory("DatasAdobe", function($resource) {
-    return $resource("http://server-adobe-github.herokuapp.com");
+    return $resource("//server-adobe-github.herokuapp.com");
 });
 
 //Offline backup of json


### PR DESCRIPTION
Site failed to load data from server-adobe-github.herokuapp.com when browsing using HTTPS protocol.
Should fix adobe/adobe.github.com#53

adobe.github.com/data/server.json should still be updated in case server-adobe-github.herokuapp.com fails for some reason.
