### PR TITLE
Correct typo in stats.html

### DIFF
--- a/views/stats.html
+++ b/views/stats.html
@@ -1,6 +1,6 @@
 <ul>
     <li><strong>{{projects.length}}</strong> public repos</li>
-    <li><strong>{{orgs.length}}</strong> organisations</li>
+    <li><strong>{{orgs.length}}</strong> organizations</li>
     <li><strong>{{langs.length}}</strong> languages</li>
     <li><strong>{{stats.bitesCode | unitNum}}bytes</strong> of code</li>
     <li><strong>{{projects[0].pushed_at | timeDiff}}</strong> since last commit</li>


### PR DESCRIPTION
To keep the spelling of 'organizations' consistent on the page.
