### PR TITLE
Footer Github Logo Removed

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,12 +313,9 @@ Okay, now let's take a look on how this website is codded!
                         <a target="_blank" href="http://pages.github.com/" title="Github Pages">Github Pages</a> and <a target="_blank" href="http://developer.github.com/v3/" title="Github API">API</a>,<br />
                         <a target="_blank" href="http://www.adobe.com/products/creativecloud.html" title="Adobe Creative Cloud">Adobe Creative Cloud</a>.</h5>
                 </div>
-                <div class="small-5 columns">
-                    <div class="logo" id="logo3">
-                        <img src="img/github_logo.svg" title="Github" alt="github_logo" />
-                    </div>
-                </div>
+                
         </div>
+       
     </div>
 
     <!-- Google Analytics  -->


### PR DESCRIPTION
The Github logo on footer marked no significance and was partially occupying the footer screen to make the UI look misty. 