### PR TITLE
Fix niceNum implementation

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -572,26 +572,11 @@ if (/MSIE [5-9]/.test(navigator.userAgent)) {
 
   app.filter("niceNum", function () {
     return function (num) {
-      var niceNum = "";
-      var step = 1;
-
-      while (num >= 1) {
-        rest = num % 1000;
-
-        //Put it in a nice string
-        if (num > 1000) {
-          if (rest < 10) {
-            rest = "00" + rest;
-          } else if (rest < 100) {
-            rest = "0" + rest;
-          }
-        }
-
-        niceNum = rest + "'" + niceNum;
-        num = Math.floor(num / 1000);
+      if (!num || isNaN(num)) {
+        return 0;
       }
 
-      return niceNum === "" ? "0" : niceNum.substring(0, niceNum.length - 1);
+      return parseInt(num, 10).toLocaleString();
     };
   });
 

--- a/js/script.js
+++ b/js/script.js
@@ -572,8 +572,8 @@ if (/MSIE [5-9]/.test(navigator.userAgent)) {
 
   app.filter("niceNum", function () {
     return function (num) {
-      if (!num || isNaN(num)) {
-        return 0;
+      if (isNaN(num)) {
+        return '0';
       }
 
       return parseInt(num, 10).toLocaleString();

--- a/js/script.js
+++ b/js/script.js
@@ -573,7 +573,7 @@ if (/MSIE [5-9]/.test(navigator.userAgent)) {
   app.filter("niceNum", function () {
     return function (num) {
       if (isNaN(num)) {
-        return '0';
+   throw new Error("Input is not a number");
       }
 
       return parseInt(num, 10).toLocaleString();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30629803/197023260-50b4527d-01c0-4b9d-8faf-2ad86de9bc0b.png)


<!--- Provide a general summary of your changes in the Title above -->

## Description
Previous state hardcoded the thousands separators.  I'm not sure which locale uses an apostrophe (') as a thousands separator but for the majority of the world that is not correct.  Number.prototype.toLocaleString will format numbers based on user's locale.

Source: https://docs.oracle.com/cd/E19455-01/806-0169/overview-9/index.html

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Readability
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
