### PR TITLE
fix: hidden show less button when user leaves the section

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -348,8 +348,8 @@ if (/MSIE [5-9]/.test(navigator.userAgent)) {
       $(".buttonMore").css({ position: "absolute", bottom: -50 });
     } else {
       var bottomScreen = scrollTop + $(window).height();
-
-      if (bottomScreen > $("#featuredOrg").offset().top + 25) {
+      
+      if ((bottomScreen > $("#featuredOrg").offset().top + 25) || (bottomScreen < $('#featuredProj').offset().top + 500)) {
         $(".buttonLess").css({ position: "absolute", bottom: -50 });
       } else {
         $(".buttonLess").css({ position: "fixed", bottom: 0 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The show less button on the repositories page persists even when scrolled up out of the section, which does not look good. The scrolling down was working properly wherein if someone scrolled down out of the section the button stuck to the end of the relative section. I used the same logic to apply the same for the top part of the section.

## Related Issue
Fixes #51 

## Motivation and Context

The button staying there was really confusing and if clicked even when out of the section you will be dragged down to the start of the section.

## How Has This Been Tested?

This was a minor bug change so simple manual testing was enough wherein I checked the button's working and hiding for every screen width and in every scenario.

## Screenshots (if appropriate):

https://github.com/adobe/adobe.github.com/assets/77831343/8196e12c-b9c4-4e14-9a9e-250eb053f1f0


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
