### PR TITLE
fixed position of show more/less button

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -212,12 +212,12 @@ if (/MSIE [5-9]/.test(navigator.userAgent)) {
     $scope.showHideProj = function () {
       if ($scope.projLast === 10) {
         $scope.projLast = 1000;
-        showMore = true;
-        $(".buttonMore").css({ position: "fixed", bottom: 0 });
+        // showMore = true;
+        // $(".buttonMore").css({ position: "fixed", bottom: 0 });
       } else {
         $("html, body").animate({ scrollTop: 380 }, 100);
         $scope.projLast = 10;
-        showMore = false;
+        // showMore = false;
       }
     };
 
@@ -299,7 +299,7 @@ if (/MSIE [5-9]/.test(navigator.userAgent)) {
   //Making the first item active
   bases.eq(active_index).addClass("active");
 
-  var showMore = false;
+  // var showMore = false;
   var scrollUpdate = function () {
     var scrollTop = $(window).scrollTop();
 
@@ -344,17 +344,18 @@ if (/MSIE [5-9]/.test(navigator.userAgent)) {
 
     // ----------------------------------------------------------------------------
     //					Show More/Less button
-    if (!showMore) {
-      $(".buttonMore").css({ position: "absolute", bottom: -50 });
-    } else {
-      var bottomScreen = scrollTop + $(window).height();
+    // if (!showMore) {
+    //   $(".buttonMore").css({ position: "absolute", bottom: -50 });
+    // } else {
+    //   var bottomScreen = scrollTop + $(window).height();
 
-      if (bottomScreen > $("#featuredOrg").offset().top + 25) {
-        $(".buttonLess").css({ position: "absolute", bottom: -50 });
-      } else {
-        $(".buttonLess").css({ position: "fixed", bottom: 0 });
-      }
-    }
+    //   if (bottomScreen > $("#featuredOrg").offset().top + 25) {
+    //     $(".buttonLess").css({ position: "absolute", bottom: -50 });
+    //   } else {
+    //     $(".buttonLess").css({ position: "fixed", bottom: 0 });
+    //   }
+    // }
+    $(".buttonMore").css({ position: "absolute", bottom: -50 });
   };
 
   /* ----------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The position property "Show More..." / "Show Less..." button was changing to "fixed" when "Show More..." button is clicked(when the repos list is expanded). This behaviour was implemented by using "showMore" boolean variable. In the fix, i've removed the usages of the "showMore" variable and permanently assigned the position as "absolute".
<!--- Describe your changes in detail -->

## Related Issue
Fixes #51
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The Button was overlapping with the content on its back. This fix resolves that issue by fixing the button at the bottom of the list irrespective of the state of "repos" list (expanded/collapsed).
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I've tested this fix by running it on my local environment. This change does not affecting any other areas of the code(since the usage of "showMore" boolean was limited to the button.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):



https://github.com/adobe/adobe.github.com/assets/100061869/70d1934e-b5ea-4303-9e11-fc236bac19ba



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
